### PR TITLE
텍스트 입력 컴포넌트 추가

### DIFF
--- a/src/components/Form/HelpMessage/index.tsx
+++ b/src/components/Form/HelpMessage/index.tsx
@@ -1,0 +1,19 @@
+import { styled } from 'stitches.config';
+import React from 'react';
+
+interface HelpMessageProps {
+  children?: React.ReactNode;
+}
+
+const HelpMessage = ({ children }: HelpMessageProps) => {
+  return <SHelpMessage>{children}</SHelpMessage>;
+};
+
+export default HelpMessage;
+
+const SHelpMessage = styled('span', {
+  marginBottom: 18,
+  display: 'inline-block',
+  fontAg: '14_medium_100',
+  color: '$gray100',
+});

--- a/src/components/Form/Label/index.tsx
+++ b/src/components/Form/Label/index.tsx
@@ -1,0 +1,31 @@
+import { styled } from 'stitches.config';
+import React from 'react';
+
+interface LabelProps {
+  required?: boolean;
+  children?: React.ReactNode;
+}
+
+const Label = ({ required, children }: LabelProps) => {
+  return <SLabel required={required}>{children}</SLabel>;
+};
+
+export default Label;
+
+const SLabel = styled('label', {
+  marginBottom: 12,
+  display: 'inline-block',
+  width: '100%',
+  fontAg: '18_semibold_100',
+  color: '$white',
+  variants: {
+    required: {
+      true: {
+        '&::after': {
+          content: '*',
+          marginLeft: 1,
+        },
+      },
+    },
+  },
+});

--- a/src/components/Form/TextInput/index.tsx
+++ b/src/components/Form/TextInput/index.tsx
@@ -1,5 +1,7 @@
 import { styled } from 'stitches.config';
 import React, { HTMLAttributes } from 'react';
+import Label from '@components/Form/Label';
+import HelpMessage from '@components/Form/HelpMessage';
 
 interface TextInputProps extends HTMLAttributes<HTMLInputElement> {
   label: string;
@@ -11,35 +13,14 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   ({ label, message, required, ...props }: TextInputProps, ref) => (
     <>
       <Label required={required}>{label}</Label>
-      {message && <Message>{message}</Message>}
+      {message && <HelpMessage>{message}</HelpMessage>}
       <Input type="text" ref={ref} {...props} />
     </>
   )
 );
 
-const Label = styled('label', {
-  marginBottom: 12,
-  display: 'inline-block',
-  width: '100%',
-  fontAg: '18_semibold_100',
-  color: '$white',
-  variants: {
-    required: {
-      true: {
-        '&::after': {
-          content: '*',
-          marginLeft: 1,
-        },
-      },
-    },
-  },
-});
-const Message = styled('span', {
-  marginBottom: 18,
-  display: 'inline-block',
-  fontAg: '14_medium_100',
-  color: '$gray100',
-});
+export default TextInput;
+
 const Input = styled('input', {
   padding: '18px 20px',
   display: 'flex',
@@ -52,5 +33,3 @@ const Input = styled('input', {
     color: '$gray100',
   },
 });
-
-export default TextInput;

--- a/src/components/Form/TextInput/index.tsx
+++ b/src/components/Form/TextInput/index.tsx
@@ -14,14 +14,14 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
     <>
       <Label required={required}>{label}</Label>
       {message && <HelpMessage>{message}</HelpMessage>}
-      <Input type="text" ref={ref} {...props} />
+      <SInput type="text" ref={ref} {...props} />
     </>
   )
 );
 
 export default TextInput;
 
-const Input = styled('input', {
+const SInput = styled('input', {
   padding: '18px 20px',
   display: 'flex',
   alignItems: 'center',

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,4 +1,4 @@
-import { styled } from '@stitches/react';
+import { styled } from 'stitches.config';
 import React, { HTMLAttributes } from 'react';
 
 interface TextInputProps extends HTMLAttributes<HTMLInputElement> {
@@ -10,10 +10,7 @@ interface TextInputProps extends HTMLAttributes<HTMLInputElement> {
 const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   ({ label, message, required, ...props }: TextInputProps, ref) => (
     <>
-      <Label>
-        {label}
-        {required ? '*' : ''}
-      </Label>
+      <Label required={required}>{label}</Label>
       {message && <Message>{message}</Message>}
       <Input type="text" ref={ref} {...props} />
     </>
@@ -24,8 +21,18 @@ const Label = styled('label', {
   marginBottom: 12,
   display: 'inline-block',
   width: '100%',
-  fontAg: '18_semibd_100',
+  fontAg: '18_semibold_100',
   color: '$white',
+  variants: {
+    required: {
+      true: {
+        '&::after': {
+          content: '*',
+          marginLeft: 1,
+        },
+      },
+    },
+  },
 });
 const Message = styled('span', {
   marginBottom: 18,

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,22 +1,49 @@
+import { styled } from '@stitches/react';
 import React from 'react';
 
 type TextInputProps = {
   label: string;
-  message: string;
-  required: boolean;
+  message?: string;
+  required?: boolean;
 };
 
 const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   ({ label, message, required }: TextInputProps, ref) => (
     <>
-      <label>
+      <Label>
         {label}
         {required ? '*' : ''}
-      </label>
-      <span>{message}</span>
-      <input type="text" ref={ref} />
+      </Label>
+      {message && <Message>{message}</Message>}
+      <Input type="text" ref={ref} />
     </>
   )
 );
+
+const Label = styled('label', {
+  marginBottom: 12,
+  display: 'inline-block',
+  width: '100%',
+  fontAg: '18_semibd_100',
+  color: '$white',
+});
+const Message = styled('span', {
+  marginBottom: 18,
+  display: 'inline-block',
+  fontAg: '14_medium_100',
+  color: '$gray100',
+});
+const Input = styled('input', {
+  padding: '18px 20px',
+  display: 'flex',
+  alignItems: 'center',
+  fontAg: '16_medium_100',
+  color: '$white',
+  background: '$black60',
+  borderRadius: 10,
+  '&::placeholder': {
+    color: '$gray100',
+  },
+});
 
 export default TextInput;

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+type TextInputProps = {
+  label: string;
+  message: string;
+  required: boolean;
+};
+
+const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
+  ({ label, message, required }: TextInputProps, ref) => (
+    <>
+      <label>
+        {label}
+        {required ? '*' : ''}
+      </label>
+      <span>{message}</span>
+      <input type="text" ref={ref} />
+    </>
+  )
+);
+
+export default TextInput;

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,21 +1,21 @@
 import { styled } from '@stitches/react';
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 
-type TextInputProps = {
+interface TextInputProps extends HTMLAttributes<HTMLInputElement> {
   label: string;
   message?: string;
   required?: boolean;
-};
+}
 
 const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
-  ({ label, message, required }: TextInputProps, ref) => (
+  ({ label, message, required, ...props }: TextInputProps, ref) => (
     <>
       <Label>
         {label}
         {required ? '*' : ''}
       </Label>
       {message && <Message>{message}</Message>}
-      <Input type="text" ref={ref} />
+      <Input type="text" ref={ref} {...props} />
     </>
   )
 );


### PR DESCRIPTION
## 🚩 관련 이슈
- close #9

## 📋 작업 내용
- [x] `TextInput` 컴포넌트 추가 및 스타일링

## 📌 PR Point
- 텍스트 입력을 목적으로 할 `TextInput` 컴포넌트를 추가했습니다.
  - `Label`, `HelpMessage` 등 다른 입력 컴포넌트에서도 사용할 수 있는 UI는 별도로 분리했습니다. 
- 나중에 react-hook-form에서 사용할 수 있게 ref를 expose 해주었습니다.

## 📸 스크린샷

### 기본(label, placeholder props 준 경우)

<img width="363" alt="Screen Shot 2022-10-22 at 5 39 34 PM" src="https://user-images.githubusercontent.com/31213226/197330005-e5cb5063-877c-4ac5-ab49-5c07be444b56.png">

### 입력 전(label, message, placeholder, required 준 경우)

<img width="363" alt="Screen Shot 2022-10-22 at 5 38 45 PM" src="https://user-images.githubusercontent.com/31213226/197330011-560ec50e-bd1e-4a24-9609-5a51e1b6a7ef.png">

#### 입력 후

<img width="335" alt="Screen Shot 2022-10-22 at 5 38 57 PM" src="https://user-images.githubusercontent.com/31213226/197330045-2dea6114-7b2e-4a5c-8870-ca069b0cd519.png">

