### PR TITLE
Select 박스에서 선택된 값이 하이라이팅 안되는 이슈 수정

### DIFF
--- a/src/components/Form/Select/OptionItem/index.tsx
+++ b/src/components/Form/Select/OptionItem/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useMemo } from 'react';
 import { Listbox } from '@headlessui/react';
 import { styled } from 'stitches.config';
 
@@ -13,8 +13,9 @@ interface OptionItemProps {
 }
 
 function OptionItem({ option }: OptionItemProps) {
+  const stringifiedValue = useMemo(() => JSON.stringify(option), [option]);
   return (
-    <Listbox.Option as={Fragment} key={option.label} value={option}>
+    <Listbox.Option as={Fragment} key={option.label} value={stringifiedValue}>
       {({ selected }) => (
         <SOptionItem selected={selected}>{option.label}</SOptionItem>
       )}

--- a/src/components/Form/Select/index.tsx
+++ b/src/components/Form/Select/index.tsx
@@ -1,4 +1,4 @@
-import { FocusEventHandler, Fragment } from 'react';
+import { FocusEventHandler, Fragment, useMemo } from 'react';
 import { Listbox } from '@headlessui/react';
 import { styled } from 'stitches.config';
 import Label from '@components/Form/Label';
@@ -22,8 +22,21 @@ function Select({
   onChange,
   onBlur,
 }: SelectProps) {
+  const stringifiedSelectedValue = useMemo(
+    () => JSON.stringify(value),
+    [value]
+  );
+  const handleChange = (stringifiedValue: string) => {
+    onChange(JSON.parse(stringifiedValue));
+  };
+
   return (
-    <Listbox value={value} onChange={onChange} onBlur={onBlur} as="div">
+    <Listbox
+      value={stringifiedSelectedValue}
+      onChange={handleChange}
+      onBlur={onBlur}
+      as="div"
+    >
       {({ open }) => (
         <>
           {label && <Label required={required}>{label}</Label>}


### PR DESCRIPTION
## 📋 작업 내용
- [x] Select 컴포넌트에서 옵션 아이템이 선택되어도 하이라이팅 안되는 이슈를 수정했습니다.
  - 원래 object로 valule 바인딩해도 잘 동작해야 할텐데,, 그게 안되서 string value를 바인딩합니다.


## 📸 스크린샷
<img width="581" alt="Screen Shot 2022-11-13 at 4 16 28 PM" src="https://user-images.githubusercontent.com/31213226/201510547-ec553c3d-ed3f-4fcc-95bb-d0a40c0d6554.png">
