### PR TITLE
모임 생성/수정 폼 validation 추가 및 날짜 포맷 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^4.10.3",
     "axios": "^1.1.3",
+    "dayjs": "^1.11.6",
     "nanoid": "^4.0.0",
     "next": "12.3.1",
     "react": "18.2.0",

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -82,8 +82,7 @@ const EditPage = () => {
     }
     async function fillForm() {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const filePromises = formData!.imageURL.map(async (obj, index) => {
-        const url = JSON.parse(obj).url;
+      const filePromises = formData!.imageURL.map(async ({ url }, index) => {
         return urlToFile(url, `image-${index}.${getExtensionFromUrl(url)}`);
       });
       const files = await Promise.all(filePromises);

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -15,6 +15,7 @@ import {
 import { getGroupById, updateGroup } from 'src/api/group';
 import { FormType, schema } from 'src/types/form';
 import { styled } from 'stitches.config';
+import dayjs from 'dayjs';
 
 const EditPage = () => {
   const queryClient = useQueryClient();
@@ -89,14 +90,16 @@ const EditPage = () => {
 
       formMethods.reset({
         ...formData,
+        startDate: dayjs(formData?.startDate).format('YYYY.MM.DD'),
+        endDate: dayjs(formData?.endDate).format('YYYY.MM.DD'),
         category: { label: formData?.category, value: formData?.category },
         files,
         // TODO: 불필요한 재정의 피할 수 있도록 API server 랑 싱크 맞추는 거 필요할 듯
         detail: {
           desc: formData?.desc,
           processDesc: formData?.processDesc,
-          mStartDate: formData?.mStartDate,
-          mEndDate: formData?.mEndDate,
+          mStartDate: dayjs(formData?.mStartDate).format('YYYY.MM.DD'),
+          mEndDate: dayjs(formData?.mEndDate).format('YYYY.MM.DD'),
           leaderDesc: formData?.leaderDesc,
           targetDesc: formData?.targetDesc,
           note: formData?.note ?? '',

--- a/src/api/group.ts
+++ b/src/api/group.ts
@@ -39,7 +39,7 @@ interface GetGroupByIdResponse {
     id: number;
     title: string;
     category: string;
-    imageURL: string[]; // NOTE: id, url 필드가 담긴 stringified JSON
+    imageURL: { id: number; url: string }[]; // NOTE: id, url 필드가 담긴 JSON
     startDate: string;
     endDate: string;
     capacity: number;

--- a/src/components/Form/ErrorMessage/index.tsx
+++ b/src/components/Form/ErrorMessage/index.tsx
@@ -1,0 +1,9 @@
+import { styled } from 'stitches.config';
+
+const ErrorMessage = styled('span', {
+  display: 'inline-block',
+  fontAg: '12_medium_100',
+  color: '$red100',
+});
+
+export default ErrorMessage;

--- a/src/components/Form/FileInput/index.tsx
+++ b/src/components/Form/FileInput/index.tsx
@@ -4,17 +4,20 @@ import HelpMessage from '../HelpMessage';
 import Label from '../Label';
 import PictureIcon from 'public/assets/svg/picture.svg';
 import { ACCEPTED_IMAGE_TYPES } from 'src/types/form';
+import ErrorMessage from '../ErrorMessage';
 
 interface FileInputProps extends HTMLAttributes<HTMLInputElement> {
   label?: string;
   value?: string;
   message?: string;
+  error?: string;
   required?: boolean;
 }
 
 export default function FileInput({
   label,
   message,
+  error,
   required,
   ...props
 }: FileInputProps) {
@@ -31,6 +34,7 @@ export default function FileInput({
           {...props}
         />
       </SInputWrapper>
+      {error && <SErrorMessage>{error}</SErrorMessage>}
     </SContainer>
   );
 }
@@ -59,4 +63,7 @@ const SInput = styled('input', {
   border: 0,
   overflow: 'hidden',
   clip: 'rect(0 0 0 0)',
+});
+const SErrorMessage = styled(ErrorMessage, {
+  marginTop: '12px',
 });

--- a/src/components/Form/Presentation/index.tsx
+++ b/src/components/Form/Presentation/index.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useState } from 'react';
+import { FieldError } from 'react-hook-form';
 import { categories } from 'src/data/categories';
 import { styled } from 'stitches.config';
 import FileInput from '../FileInput';
@@ -70,12 +71,13 @@ function Presentation({
       <STitleField>
         <FormController
           name="title"
-          render={({ field }) => (
+          render={({ field, fieldState: { error } }) => (
             <TextInput
               label="모임 제목"
               message="최대 30자 이내로 입력"
               placeholder="제목 입력"
               required
+              error={error?.message}
               {...field}
             />
           )}
@@ -86,16 +88,22 @@ function Presentation({
       <FormController
         name="category"
         defaultValue={categories[0]}
-        render={({ field: { value, onChange, onBlur } }) => (
-          <Select
-            label="모임 카테고리"
-            options={categories}
-            required
-            value={value}
-            onChange={onChange}
-            onBlur={onBlur}
-          />
-        )}
+        render={({ field: { value, onChange, onBlur }, fieldState }) => {
+          const error = (
+            fieldState.error as (FieldError & { value: FieldError }) | undefined
+          )?.value;
+          return (
+            <Select
+              label="모임 카테고리"
+              options={categories}
+              required
+              error={error?.message}
+              value={value}
+              onChange={onChange}
+              onBlur={onBlur}
+            />
+          );
+        }}
       ></FormController>
 
       {/* 이미지 */}
@@ -116,9 +124,13 @@ function Presentation({
           <div style={{ display: imageUrls.length < 6 ? 'block' : 'none' }}>
             <FormController
               name="files"
-              render={({ field: { value, onChange, onBlur } }) => (
+              render={({
+                field: { value, onChange, onBlur },
+                fieldState: { error },
+              }) => (
                 <FileInput
                   // NOTE: FileInput의 value는 filename(string)이고, FormController의 value는 File[] 이다.
+                  error={error?.message}
                   value={filename}
                   onChange={handleAddFiles({ value, onChange })}
                   onBlur={onBlur}
@@ -132,17 +144,33 @@ function Presentation({
       {/* 모집 기간 */}
       <div>
         <Label required={true}>모집 기간</Label>
-        <HelpMessage>최대 6개까지 첨부 가능, 이미지 사이즈 제약</HelpMessage>
+        <HelpMessage>시작 날짜와 끝 날짜 순서에 주의</HelpMessage>
         <SApplicationFieldWrapper>
           <SApplicationField>
             <FormController
               name="startDate"
-              render={({ field }) => (
-                <TextInput placeholder="YYYY.MM.DD" required {...field} />
-              )}
+              render={({ field, formState: { errors } }) => {
+                const dateError = errors as
+                  | {
+                      startDate?: FieldError;
+                      endDate?: FieldError;
+                    }
+                  | undefined;
+                return (
+                  <TextInput
+                    placeholder="YYYY.MM.DD"
+                    error={
+                      dateError?.startDate?.message ||
+                      dateError?.endDate?.message
+                    }
+                    required
+                    {...field}
+                  />
+                );
+              }}
             ></FormController>
           </SApplicationField>
-          -
+          <span style={{ marginTop: '14px' }}>-</span>
           <SApplicationField>
             <FormController
               name="endDate"
@@ -158,7 +186,7 @@ function Presentation({
       <SMemberCountField>
         <FormController
           name="capacity"
-          render={({ field }) => (
+          render={({ field, fieldState: { error } }) => (
             <TextInput
               type="number"
               label="모집 인원"
@@ -166,6 +194,7 @@ function Presentation({
               right={
                 <span style={{ marginLeft: '10px', color: '#a9a9a9' }}>명</span>
               }
+              error={error?.message}
               {...field}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 field.onChange(+e.target.value)
@@ -183,8 +212,13 @@ function Presentation({
         </Label>
         <FormController
           name="detail.desc"
-          render={({ field }) => (
-            <Textarea placeholder="모임 소개" maxLength={500} {...field} />
+          render={({ field, fieldState: { error } }) => (
+            <Textarea
+              placeholder="모임 소개"
+              maxLength={300}
+              error={error?.message}
+              {...field}
+            />
           )}
         ></FormController>
       </div>
@@ -196,8 +230,13 @@ function Presentation({
         </Label>
         <FormController
           name="detail.processDesc"
-          render={({ field }) => (
-            <Textarea placeholder="진행 방식 소개" maxLength={500} {...field} />
+          render={({ field, fieldState: { error } }) => (
+            <Textarea
+              placeholder="진행 방식 소개"
+              maxLength={300}
+              error={error?.message}
+              {...field}
+            />
           )}
         ></FormController>
       </div>
@@ -211,9 +250,25 @@ function Presentation({
           <SDateField>
             <FormController
               name="detail.mStartDate"
-              render={({ field }) => (
-                <TextInput placeholder="YYYY.MM.DD" required {...field} />
-              )}
+              render={({ field, formState: { errors } }) => {
+                const dateError = errors.detail as
+                  | (FieldError & {
+                      mStartDate?: FieldError;
+                      mEndDate?: FieldError;
+                    })
+                  | undefined;
+                return (
+                  <TextInput
+                    placeholder="YYYY.MM.DD"
+                    required
+                    error={
+                      dateError?.mStartDate?.message ||
+                      dateError?.mEndDate?.message
+                    }
+                    {...field}
+                  />
+                );
+              }}
             ></FormController>
           </SDateField>
           -
@@ -235,8 +290,13 @@ function Presentation({
         </Label>
         <FormController
           name="detail.leaderDesc"
-          render={({ field }) => (
-            <Textarea placeholder="개설자 소개" maxLength={500} {...field} />
+          render={({ field, fieldState: { error } }) => (
+            <Textarea
+              placeholder="개설자 소개"
+              maxLength={300}
+              error={error?.message}
+              {...field}
+            />
           )}
         ></FormController>
       </div>
@@ -248,10 +308,11 @@ function Presentation({
         </Label>
         <FormController
           name="detail.targetDesc"
-          render={({ field }) => (
+          render={({ field, fieldState: { error } }) => (
             <Textarea
               placeholder="이런 분을 찾습니다."
               maxLength={300}
+              error={error?.message}
               {...field}
             />
           )}
@@ -263,8 +324,13 @@ function Presentation({
         <Label size="small">유의사항</Label>
         <FormController
           name="detail.note"
-          render={({ field }) => (
-            <Textarea placeholder="유의 사항 입력" maxLength={500} {...field} />
+          render={({ field, fieldState: { error } }) => (
+            <Textarea
+              placeholder="유의 사항 입력"
+              maxLength={300}
+              error={error?.message}
+              {...field}
+            />
           )}
         ></FormController>
       </div>
@@ -297,7 +363,6 @@ const SFileInputWrapper = styled('div', {
 });
 const SApplicationFieldWrapper = styled('div', {
   display: 'flex',
-  alignItems: 'center',
   color: '$gray100',
   gap: '12px',
 });

--- a/src/components/Form/Select/index.tsx
+++ b/src/components/Form/Select/index.tsx
@@ -4,12 +4,14 @@ import { styled } from 'stitches.config';
 import Label from '@components/Form/Label';
 import Button from './Button';
 import OptionItem, { Option } from './OptionItem';
+import ErrorMessage from '../ErrorMessage';
 
 interface SelectProps {
   label?: string;
   value?: Option;
   options: Option[];
   required?: boolean;
+  error?: string;
   onChange: (value: Option) => void;
   onBlur?: FocusEventHandler<HTMLDivElement>;
 }
@@ -19,6 +21,7 @@ function Select({
   value,
   options,
   required,
+  error,
   onChange,
   onBlur,
 }: SelectProps) {
@@ -31,30 +34,33 @@ function Select({
   };
 
   return (
-    <Listbox
-      value={stringifiedSelectedValue}
-      onChange={handleChange}
-      onBlur={onBlur}
-      as="div"
-    >
-      {({ open }) => (
-        <>
-          {label && <Label required={required}>{label}</Label>}
-          <Button value={value} open={open} />
+    <div>
+      <Listbox
+        value={stringifiedSelectedValue}
+        onChange={handleChange}
+        onBlur={onBlur}
+        as="div"
+      >
+        {({ open }) => (
+          <>
+            {label && <Label required={required}>{label}</Label>}
+            <Button value={value} open={open} />
 
-          <Listbox.Options as={Fragment}>
-            <SOptionList>
-              {options
-                // NOTE: value가 null 이면 placeholder 전용 옵션. 이는 제거하고 목록을 보여주자.
-                .filter(option => option.value)
-                .map(option => (
-                  <OptionItem key={option.value} option={option} />
-                ))}
-            </SOptionList>
-          </Listbox.Options>
-        </>
-      )}
-    </Listbox>
+            <Listbox.Options as={Fragment}>
+              <SOptionList>
+                {options
+                  // NOTE: value가 null 이면 placeholder 전용 옵션. 이는 제거하고 목록을 보여주자.
+                  .filter(option => option.value)
+                  .map(option => (
+                    <OptionItem key={option.value} option={option} />
+                  ))}
+              </SOptionList>
+            </Listbox.Options>
+          </>
+        )}
+      </Listbox>
+      {error && <SErrorMessage>{error}</SErrorMessage>}
+    </div>
   );
 }
 
@@ -68,4 +74,7 @@ const SOptionList = styled('ul', {
   borderRadius: 10,
   mt: '$8',
   background: '$black40',
+});
+const SErrorMessage = styled(ErrorMessage, {
+  marginTop: '12px',
 });

--- a/src/components/Form/TextInput/index.tsx
+++ b/src/components/Form/TextInput/index.tsx
@@ -2,17 +2,22 @@ import { styled } from 'stitches.config';
 import React, { HTMLAttributes } from 'react';
 import Label from '@components/Form/Label';
 import HelpMessage from '@components/Form/HelpMessage';
+import ErrorMessage from '../ErrorMessage';
 
 interface TextInputProps extends HTMLAttributes<HTMLInputElement> {
   type?: string;
   label?: string;
   message?: string;
+  error?: string;
   required?: boolean;
   right?: React.ReactNode;
 }
 
 const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
-  ({ type, label, message, required, ...props }: TextInputProps, ref) => (
+  (
+    { type, label, message, error, required, ...props }: TextInputProps,
+    ref
+  ) => (
     <SContainer>
       {label && <Label required={required}>{label}</Label>}
       {message && <HelpMessage>{message}</HelpMessage>}
@@ -20,6 +25,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
         <SInput type={type || 'text'} ref={ref} {...props} />
         {props.right}
       </SInputWrapper>
+      {error && <SErrorMessage>{error}</SErrorMessage>}
     </SContainer>
   )
 );
@@ -46,4 +52,7 @@ const SInput = styled('input', {
   '&::placeholder': {
     color: '$gray100',
   },
+});
+const SErrorMessage = styled(ErrorMessage, {
+  marginTop: '12px',
 });

--- a/src/components/Form/Textarea/index.tsx
+++ b/src/components/Form/Textarea/index.tsx
@@ -2,27 +2,32 @@ import { styled } from 'stitches.config';
 import React, { HTMLAttributes } from 'react';
 import Label from '@components/Form/Label';
 import HelpMessage from '@components/Form/HelpMessage';
+import ErrorMessage from '../ErrorMessage';
 
 interface TextareaProps extends HTMLAttributes<HTMLTextAreaElement> {
   label?: string;
   value: string;
   message?: string;
+  error?: string;
   required?: boolean;
   maxLength?: number;
 }
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ label, message, required, ...props }: TextareaProps, ref) => {
+  ({ label, message, error, required, ...props }: TextareaProps, ref) => {
     return (
       <SContainer>
         <Label required={required}>{label}</Label>
         {message && <HelpMessage>{message}</HelpMessage>}
         <STextarea ref={ref} {...props} />
-        {props.maxLength && (
-          <STextCount overflow={props.value.length > props.maxLength}>
-            {props.value.length} / {props.maxLength}
-          </STextCount>
-        )}
+        <SBottomContainer>
+          {error && <SErrorMessage>{error}</SErrorMessage>}
+          {props.maxLength && (
+            <STextCount overflow={props.value.length > props.maxLength}>
+              {props.value.length} / {props.maxLength}
+            </STextCount>
+          )}
+        </SBottomContainer>
       </SContainer>
     );
   }
@@ -49,9 +54,15 @@ const STextarea = styled('textarea', {
     color: '$gray100',
   },
 });
-const STextCount = styled('span', {
+const SBottomContainer = styled('div', {
   marginTop: '12px',
-  alignSelf: 'flex-end',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+const STextCount = styled('span', {
+  width: '100%',
+  textAlign: 'right',
   fontAg: '12_medium_100',
   color: '$gray60',
   variants: {
@@ -61,4 +72,7 @@ const STextCount = styled('span', {
       },
     },
   },
+});
+const SErrorMessage = styled(ErrorMessage, {
+  whiteSpace: 'nowrap',
 });

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,13 +1,22 @@
+import dayjs from 'dayjs';
 import { z } from 'zod';
 
 export const schema = z.object({
-  title: z.string().max(30).min(1),
+  title: z
+    .string()
+    .max(30, { message: '30자 까지 입력할 수 있습니다.' })
+    .min(1, { message: '모임 제목을 입력해주세요.' }),
   category: z.object({
     label: z.string(),
-    value: z.string(),
+    value: z.string({
+      required_error: '카테고리를 선택해주세요.',
+      invalid_type_error: '카테고리를 선택해주세요.',
+    }),
   }),
   files: z
-    .any()
+    .any({
+      required_error: '이미지를 추가해주세요.',
+    })
     .refine((files: FileList) => files?.length > 0, '이미지를 추가해주세요.')
     .refine(
       (files: FileList) => files?.[0]?.size <= MAX_FILE_SIZE,
@@ -17,17 +26,70 @@ export const schema = z.object({
       (files: FileList) => ACCEPTED_IMAGE_TYPES.includes(files?.[0]?.type),
       '.jpg, .jpeg, .png, .webp, .gif 파일만 업로드할 수 있습니다.'
     ),
-  startDate: z.string().min(1),
-  endDate: z.string().min(1),
-  capacity: z.number().gt(0),
+  startDate: z
+    .string()
+    .min(10, { message: '모집 기간을 입력해주세요.' })
+    .max(10, { message: 'YYYY.MM.DD 형식으로 입력해주세요.' })
+    .refine(datetime => dayjs(datetime, 'YYYY.MM.DD').isValid(), {
+      message: 'YYYY.MM.DD 형식으로 입력해주세요.',
+    }),
+  endDate: z
+    .string()
+    .min(10, { message: '모집 기간을 입력해주세요.' })
+    .max(10, { message: 'YYYY.MM.DD 형식으로 입력해주세요.' })
+    .refine(datetime => dayjs(datetime, 'YYYY.MM.DD').isValid(), {
+      message: 'YYYY.MM.DD 형식으로 입력해주세요.',
+    }),
+  capacity: z
+    .number({
+      required_error: '모집 인원을 입력해주세요.',
+      invalid_type_error: '모집 인원을 입력해주세요.',
+    })
+    .gt(0, { message: '0보다 큰 값을 입력해주세요.' }),
   detail: z.object({
-    desc: z.string().min(1),
-    processDesc: z.string().min(1),
-    mStartDate: z.string().min(1),
-    mEndDate: z.string().min(1),
-    leaderDesc: z.string().min(1),
-    targetDesc: z.string().min(1),
-    note: z.string().optional().nullable(),
+    desc: z
+      .string()
+      .min(1, {
+        message: '모임 소개를 입력해주세요.',
+      })
+      .max(300, { message: '300자 까지 입력 가능합니다.' }),
+    processDesc: z
+      .string()
+      .min(1, {
+        message: '진행 방식 소개를 입력해주세요.',
+      })
+      .max(300, { message: '300자 까지 입력 가능합니다.' }),
+    mStartDate: z
+      .string()
+      .min(10, { message: '모임 기간을 입력해주세요.' })
+      .max(10, { message: 'YYYY.MM.DD 형식으로 입력해주세요.' })
+      .refine(datetime => dayjs(datetime, 'YYYY.MM.DD').isValid(), {
+        message: 'YYYY.MM.DD 형식으로 입력해주세요.',
+      }),
+    mEndDate: z
+      .string()
+      .min(10, { message: '모임 기간을 입력해주세요.' })
+      .max(10, { message: 'YYYY.MM.DD 형식으로 입력해주세요.' })
+      .refine(datetime => dayjs(datetime, 'YYYY.MM.DD').isValid(), {
+        message: 'YYYY.MM.DD 형식으로 입력해주세요.',
+      }),
+    leaderDesc: z
+      .string()
+      .min(1, {
+        message: '개설자 소개를 입력해주세요.',
+      })
+      .max(300, { message: '300자 까지 입력 가능합니다.' }),
+    targetDesc: z
+      .string()
+      .min(1, {
+        message: '모집 대상을 입력해주세요.',
+      })
+      .max(300, { message: '300자 까지 입력 가능합니다.' }),
+    note: z
+      .string()
+      .max(300, { message: '300자 까지 입력 가능합니다.' })
+      .optional()
+      .nullable(),
   }),
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,6 +1830,11 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+dayjs@^1.11.6:
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.6.tgz#2e79a226314ec3ec904e3ee1dd5a4f5e5b1c7afb"
+  integrity sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
## 🚩 관련 이슈
- close #42 

## 📋 작업 내용
- [x] `schema`에 폼 validation 메시지 추가
- [x] `ErrorMessage` 컴포넌트 추가 및 `TextInput`, `Textarea`, `Select`, `FileInput` 입력 필드에 `error` prop 추가
- [x] `Presentation`의 각 폼 필드에서 필드 에러를 입력 컴포넌트의 props로 전달
- [x] `dayjs` 라이브러리 추가 및 date formatting, schema validation 적용

## 📌 PR Point
- `schema`에는 메시지 추가가 전부에요. 날짜 필드에 한해서 포맷 관련 validation을 적용하기 위해 `z.refine()` 를 사용했어요.
- `Presentation` 에서 `FormController`의 render function이 `fieldState`, `formState`를 내려주고 있는데, 여기서 `error`를 가져와 입력 필드로 내려주도록 했어요.

## 📸 스크린샷


https://user-images.githubusercontent.com/31213226/202913088-22c30b61-c058-42e5-a47c-31f01db3fbaf.mov

